### PR TITLE
Add flag to suppress visual studio compile error _SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS 

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Project-level configuration.
 cmake_minimum_required(VERSION 3.14)
 project(iium_schedule LANGUAGES CXX)
+# Temporary workaround for upstream issue: https://github.com/pichillilorenzo/flutter_inappwebview/issues/2839
+add_definitions(-D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.


### PR DESCRIPTION
This PR add flag to suppress error when building for windows. Upstream issue can be viewed [here](https://github.com/pichillilorenzo/flutter_inappwebview/issues/2839). Closes #130